### PR TITLE
Invoke sendMessage() on the current event loop

### DIFF
--- a/Sources/KituraWebSocket/WebSocketConnection.swift
+++ b/Sources/KituraWebSocket/WebSocketConnection.swift
@@ -67,10 +67,10 @@ public class WebSocketConnection {
             if let message = withMessage {
                 var buffer = context.channel.allocator.buffer(capacity: message.count)
                 buffer.writeString(message)
-                sendMessage(with: .ping, data: buffer)
+                self.sendMessage(with: .ping, data: buffer)
             } else {
                 let emptyBuffer = context.channel.allocator.buffer(capacity: 1)
-                sendMessage(with: .ping, data: emptyBuffer)
+                self.sendMessage(with: .ping, data: emptyBuffer)
             }
         }
     }
@@ -84,7 +84,7 @@ public class WebSocketConnection {
         context.eventLoop.execute {
             var buffer = context.channel.allocator.buffer(capacity: message.count)
             buffer.writeBytes(message)
-            sendMessage(with: asBinary ? .binary : .text, data: buffer)
+            self.sendMessage(with: asBinary ? .binary : .text, data: buffer)
         }
     }
 

--- a/Sources/KituraWebSocket/WebSocketConnection.swift
+++ b/Sources/KituraWebSocket/WebSocketConnection.swift
@@ -63,25 +63,29 @@ public class WebSocketConnection {
             Log.error("ChannelHandlerContext unavailable")
             return
         }
-        if let message = withMessage {
-            var buffer = context.channel.allocator.buffer(capacity: message.count)
-            buffer.writeString(message)
-            sendMessage(with: .ping, data: buffer)
-        } else {
-            let emptyBuffer = context.channel.allocator.buffer(capacity: 1)
-            sendMessage(with: .ping, data: emptyBuffer)
+        context.eventLoop.execute {
+            if let message = withMessage {
+                var buffer = context.channel.allocator.buffer(capacity: message.count)
+                buffer.writeString(message)
+                sendMessage(with: .ping, data: buffer)
+            } else {
+                let emptyBuffer = context.channel.allocator.buffer(capacity: 1)
+                sendMessage(with: .ping, data: emptyBuffer)
+            }
         }
     }
 
     public func send(message: Data, asBinary: Bool = true) {
-       guard active else { return }
-       guard let context = context else {
-           Log.error("ChannelHandlerContext unavailable")
-           return
-       }
-       var buffer = context.channel.allocator.buffer(capacity: message.count)
-       buffer.writeBytes(message)
-       sendMessage(with: asBinary ? .binary : .text, data: buffer)
+        guard active else { return }
+        guard let context = context else {
+            Log.error("ChannelHandlerContext unavailable")
+            return
+        }
+        context.eventLoop.execute {
+            var buffer = context.channel.allocator.buffer(capacity: message.count)
+            buffer.writeBytes(message)
+            sendMessage(with: asBinary ? .binary : .text, data: buffer)
+        }
     }
 
     public func send(message: String) {


### PR DESCRIPTION
A registered WebSocketService may invoke `ping(withMessage:)`,
`send(message:asBinary:)` and `send(message:)` from a thread different from the
EventLoop thread that drives the WebSocketConnection. These functions allocate
`ByteBuffer`s and write to the connected Channel. We must make sure that the
buffer allocator and `sendMessage()` are invoked on the EventLoop related to the
current WebSocketConnection.