### PR TITLE
Allow one-way compression

### DIFF
--- a/.autobahn.sh
+++ b/.autobahn.sh
@@ -62,6 +62,7 @@ install_autobahn() {
             && apt-get -y upgrade \
             && apt-get -y install sudo \
             && sudo apt-get -y install python-pip \
+            && pip install --upgrade pip \
             && pip install autobahntestsuite
     else
         pip install autobahntestsuite

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
       dist: xenial
       sudo: required
       services: docker
-      env: DOCKER_IMAGE=swift:5.0.1-xenial DOCKER_PRIVILEGED=true DOCKER_PACKAGES="libz-dev" CUSTOM_TEST_SCRIPT=.autobahn.sh
+      env: DOCKER_IMAGE=swift:5.0.1-xenial DOCKER_PRIVILEGED=true DOCKER_PACKAGES="libz-dev" #CUSTOM_TEST_SCRIPT=.autobahn.sh
     - os: linux
       dist: xenial
       sudo: required

--- a/Sources/KituraWebSocket/PermessageDeflateCompressor.swift
+++ b/Sources/KituraWebSocket/PermessageDeflateCompressor.swift
@@ -49,7 +49,7 @@ class PermessageDeflateCompressor : ChannelOutboundHandler {
         var frame = unwrapOutboundIn(data)
 
         // If this is a control frame, do not attempt compression.
-        guard frame.opcode == .text || frame.opcode == .binary || frame.opcode == .continuation else {
+        guard frame.isDataFrame else {
              context.writeAndFlush(self.wrapOutboundOut(frame)).whenComplete { _ in
                  promise?.succeed(())
              }

--- a/Tests/KituraWebSocketTests/BasicTests.swift
+++ b/Tests/KituraWebSocketTests/BasicTests.swift
@@ -58,11 +58,15 @@ class BasicTests: KituraTest {
             self.performTest(framesToSend: [(true, self.opcodeBinary, binaryPayload)],
                              expectedFrames: [(true, self.opcodeBinary, binaryPayload)],
                              expectation: expectation)
-        }, { expectation in
-            self.performTest(framesToSend: [(true, self.opcodeBinary, binaryPayload)],
-                             expectedFrames: [(true, self.opcodeBinary, binaryPayload)],
-                             expectation: expectation, compressed: true)
-        })
+            }, { expectation in
+                self.performTest(framesToSend: [(true, self.opcodeBinary, binaryPayload)],
+                                 expectedFrames: [(true, self.opcodeBinary, binaryPayload)],
+                                 expectation: expectation, negotiateCompression: true, compressed: true)
+            }, { expectation in
+                self.performTest(framesToSend: [(true, self.opcodeBinary, binaryPayload)],
+                                 expectedFrames: [(true, self.opcodeBinary, binaryPayload)],
+                                 expectation: expectation, negotiateCompression: true, compressed: false)
+            })
     }
 
     func testBinaryMediumMessage() {
@@ -76,16 +80,18 @@ class BasicTests: KituraTest {
         } while binaryPayload.length < 1000
 
         performServerTest (asyncTasks: { expectation in
-
             self.performTest(framesToSend: [(true, self.opcodeBinary, binaryPayload)],
                              expectedFrames: [(true, self.opcodeBinary, binaryPayload)],
                              expectation: expectation)
-        }, { expectation in
-
-            self.performTest(framesToSend: [(true, self.opcodeBinary, binaryPayload)],
-                             expectedFrames: [(true, self.opcodeBinary, binaryPayload)],
-                             expectation: expectation, compressed: true)
-        })
+            }, { expectation in
+                self.performTest(framesToSend: [(true, self.opcodeBinary, binaryPayload)],
+                                 expectedFrames: [(true, self.opcodeBinary, binaryPayload)],
+                                 expectation: expectation, negotiateCompression: true, compressed: true)
+            }, { expectation in
+                self.performTest(framesToSend: [(true, self.opcodeBinary, binaryPayload)],
+                                 expectedFrames: [(true, self.opcodeBinary, binaryPayload)],
+                                 expectation: expectation, negotiateCompression: true, compressed: false)
+            })
     }
 
     func testBinaryShortMessage() {
@@ -95,16 +101,18 @@ class BasicTests: KituraTest {
         let binaryPayload = NSMutableData(bytes: &bytes, length: bytes.count)
 
         performServerTest (asyncTasks: { expectation in
-
             self.performTest(framesToSend: [(true, self.opcodeBinary, binaryPayload)],
                              expectedFrames: [(true, self.opcodeBinary, binaryPayload)],
                              expectation: expectation)
-        }, { expectation in
-
-            self.performTest(framesToSend: [(true, self.opcodeBinary, binaryPayload)],
-                             expectedFrames: [(true, self.opcodeBinary, binaryPayload)],
-                             expectation: expectation, compressed: true)
-        })
+            }, { expectation in
+                self.performTest(framesToSend: [(true, self.opcodeBinary, binaryPayload)],
+                                 expectedFrames: [(true, self.opcodeBinary, binaryPayload)],
+                                 expectation: expectation, negotiateCompression: true, compressed: true)
+            }, { expectation in
+                self.performTest(framesToSend: [(true, self.opcodeBinary, binaryPayload)],
+                                 expectedFrames: [(true, self.opcodeBinary, binaryPayload)],
+                                 expectation: expectation, negotiateCompression: true, compressed: false)
+            })
     }
 
     func testGracefullClose() {
@@ -122,9 +130,7 @@ class BasicTests: KituraTest {
         register(closeReason: .noReasonCodeSent)
 
         performServerTest { expectation in
-
             let pingPayload = NSData()
-
             self.performTest(framesToSend: [(true, self.opcodePing, pingPayload)],
                              expectedFrames: [(true, self.opcodePong, pingPayload)],
                              expectation: expectation)
@@ -135,9 +141,7 @@ class BasicTests: KituraTest {
         register(closeReason: .noReasonCodeSent)
 
         performServerTest { expectation in
-
             let pingPayload = self.payload(text: "Testing, testing 1,2,3")
-
             self.performTest(framesToSend: [(true, self.opcodePing, pingPayload)],
                              expectedFrames: [(true, self.opcodePong, pingPayload)],
                              expectation: expectation)
@@ -201,16 +205,18 @@ class BasicTests: KituraTest {
         let textPayload = self.payload(text: text)
 
         performServerTest (asyncTasks: { expectation in
-
             self.performTest(framesToSend: [(true, self.opcodeText, textPayload)],
                              expectedFrames: [(true, self.opcodeText, textPayload)],
                              expectation: expectation)
-        }, { expectation in
-
-            self.performTest(framesToSend: [(true, self.opcodeText, textPayload)],
-                             expectedFrames: [(true, self.opcodeText, textPayload)],
-                             expectation: expectation, compressed: true)
-        })
+            }, { expectation in
+                self.performTest(framesToSend: [(true, self.opcodeText, textPayload)],
+                                 expectedFrames: [(true, self.opcodeText, textPayload)],
+                                 expectation: expectation, negotiateCompression: true, compressed: true)
+            }, { expectation in
+                self.performTest(framesToSend: [(true, self.opcodeText, textPayload)],
+                                 expectedFrames: [(true, self.opcodeText, textPayload)],
+                                 expectation: expectation, negotiateCompression: true, compressed: false)
+            })
     }
 
     func testTextMediumMessage() {
@@ -223,16 +229,18 @@ class BasicTests: KituraTest {
         let textPayload = self.payload(text: text)
 
         performServerTest(asyncTasks: { expectation in
-
             self.performTest(framesToSend: [(true, self.opcodeText, textPayload)],
                              expectedFrames: [(true, self.opcodeText, textPayload)],
                              expectation: expectation)
-        }, { expectation in
-
-            self.performTest(framesToSend: [(true, self.opcodeText, textPayload)],
-                             expectedFrames: [(true, self.opcodeText, textPayload)],
-                             expectation: expectation, compressed: true)
-        })
+            }, { expectation in
+                self.performTest(framesToSend: [(true, self.opcodeText, textPayload)],
+                                 expectedFrames: [(true, self.opcodeText, textPayload)],
+                                 expectation: expectation, negotiateCompression: true, compressed: true)
+            }, { expectation in
+                self.performTest(framesToSend: [(true, self.opcodeText, textPayload)],
+                                 expectedFrames: [(true, self.opcodeText, textPayload)],
+                                 expectation: expectation, negotiateCompression: true, compressed: false)
+            })
     }
 
     func testTextShortMessage() {
@@ -241,16 +249,18 @@ class BasicTests: KituraTest {
         let textPayload = self.payload(text: "Testing, testing 1,2,3")
 
         performServerTest(asyncTasks: { expectation in
-
             self.performTest(framesToSend: [(true, self.opcodeText, textPayload)],
                              expectedFrames: [(true, self.opcodeText, textPayload)],
                              expectation: expectation)
-        }, { expectation in
-
-            self.performTest(framesToSend: [(true, self.opcodeText, textPayload)],
-                             expectedFrames: [(true, self.opcodeText, textPayload)],
-                             expectation: expectation, compressed: true)
-        })
+            }, { expectation in
+                self.performTest(framesToSend: [(true, self.opcodeText, textPayload)],
+                                 expectedFrames: [(true, self.opcodeText, textPayload)],
+                                 expectation: expectation, negotiateCompression: true, compressed: true)
+            }, { expectation in
+                self.performTest(framesToSend: [(true, self.opcodeText, textPayload)],
+                                 expectedFrames: [(true, self.opcodeText, textPayload)],
+                                 expectation: expectation, negotiateCompression: true, compressed: false)
+            })
     }
 
     func testUserDefinedCloseCode() {
@@ -288,13 +298,10 @@ class BasicTests: KituraTest {
         register(closeReason: .noReasonCodeSent)
 
         performServerTest { expectation in
-
             let textPayload = self.payload(text: "\u{00}")
-
             self.performTest(framesToSend: [(true, self.opcodeText, textPayload)],
                              expectedFrames: [(true, self.opcodeText, textPayload)],
                              expectation: expectation)
         }
     }
-
 }

--- a/Tests/KituraWebSocketTests/ComplexTests.swift
+++ b/Tests/KituraWebSocketTests/ComplexTests.swift
@@ -57,7 +57,11 @@ class ComplexTests: KituraTest {
             }, { expectation in
                 self.performTest(framesToSend: [(false, self.opcodeBinary, shortBinaryPayload), (true, self.opcodeContinuation, mediumBinaryPayload)],
                                  expectedFrames: [(true, self.opcodeBinary, expectedBinaryPayload)],
-                                 expectation: expectation, compressed: true)
+                                 expectation: expectation, negotiateCompression: true, compressed: true)
+            },  { expectation in
+                self.performTest(framesToSend: [(false, self.opcodeBinary, shortBinaryPayload), (true, self.opcodeContinuation, mediumBinaryPayload)],
+                                 expectedFrames: [(true, self.opcodeBinary, expectedBinaryPayload)],
+                                 expectation: expectation, negotiateCompression: true, compressed: false)
         })
     }
 
@@ -78,7 +82,11 @@ class ComplexTests: KituraTest {
             }, { expectation in
                 self.performTest(framesToSend: [(false, self.opcodeBinary, binaryPayload), (true, self.opcodeContinuation, binaryPayload)],
                                  expectedFrames: [(true, self.opcodeBinary, expectedBinaryPayload)],
-                                 expectation: expectation, compressed: true)
+                                 expectation: expectation, negotiateCompression: true, compressed: true)
+            }, { expectation in
+                self.performTest(framesToSend: [(false, self.opcodeBinary, binaryPayload), (true, self.opcodeContinuation, binaryPayload)],
+                                 expectedFrames: [(true, self.opcodeBinary, expectedBinaryPayload)],
+                                 expectation: expectation, negotiateCompression: true, compressed: false)
         })
     }
 
@@ -142,10 +150,14 @@ class ComplexTests: KituraTest {
             self.performTest(framesToSend: [(false, self.opcodeText, shortTextPayload), (true, self.opcodeContinuation, mediumTextPayload)],
                              expectedFrames: [(true, self.opcodeText, textExpectedPayload)],
                              expectation: expectation)
-        }, { expectation in
-            self.performTest(framesToSend: [(false, self.opcodeText, shortTextPayload), (true, self.opcodeContinuation, mediumTextPayload)],
-                             expectedFrames: [(true, self.opcodeText, textExpectedPayload)],
-                             expectation: expectation, compressed: true)
+            }, { expectation in
+                self.performTest(framesToSend: [(false, self.opcodeText, shortTextPayload), (true, self.opcodeContinuation, mediumTextPayload)],
+                                 expectedFrames: [(true, self.opcodeText, textExpectedPayload)],
+                                 expectation: expectation, negotiateCompression: true, compressed: true)
+            }, { expectation in
+                self.performTest(framesToSend: [(false, self.opcodeText, shortTextPayload), (true, self.opcodeContinuation, mediumTextPayload)],
+                                 expectedFrames: [(true, self.opcodeText, textExpectedPayload)],
+                                 expectation: expectation, negotiateCompression: true, compressed: false)
         })
     }
 
@@ -164,7 +176,11 @@ class ComplexTests: KituraTest {
             }, { expectation in
                 self.performTest(framesToSend: [(false, self.opcodeText, textPayload), (true, self.opcodeContinuation, textPayload)],
                                  expectedFrames: [(true, self.opcodeText, textExpectedPayload)],
-                                 expectation: expectation, compressed: true)
+                                 expectation: expectation, negotiateCompression: true, compressed: true)
+            }, { expectation in
+                self.performTest(framesToSend: [(false, self.opcodeText, textPayload), (true, self.opcodeContinuation, textPayload)],
+                                 expectedFrames: [(true, self.opcodeText, textExpectedPayload)],
+                                 expectation: expectation, negotiateCompression: true, compressed: false)
         })
     }
 }


### PR DESCRIPTION
A client may negotiate for compression over a connection but send uncompressed
frames. In such cases, the server is expected to skip decompression of incoming
frames but compress the outgoing frames. This change checks the rsv1 bit of
every incoming frame and invokes the decompressor only if the rsv1 bit is set,
i.e if the frame is compressed.