### PR TITLE
tests: add test that uses a uri with query params

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
       dist: xenial
       sudo: required
       services: docker
-      env: DOCKER_IMAGE=swift:5.0.1-xenial DOCKER_PRIVILEGED=true DOCKER_PACKAGES="libz-dev" #CUSTOM_TEST_SCRIPT=.autobahn.sh
+      env: DOCKER_IMAGE=swift:5.0.1-xenial DOCKER_PRIVILEGED=true DOCKER_PACKAGES="libz-dev" 
     - os: linux
       dist: xenial
       sudo: required

--- a/Tests/KituraWebSocketTests/BasicTests.swift
+++ b/Tests/KituraWebSocketTests/BasicTests.swift
@@ -38,6 +38,7 @@ class BasicTests: KituraTest {
             ("testTextLongMessage", testTextLongMessage),
             ("testTextMediumMessage", testTextMediumMessage),
             ("testTextShortMessage", testTextShortMessage),
+            ("testTextShortMessageWithQueryParams", testTextShortMessageWithQueryParams),
             ("testNullCharacter", testNullCharacter),
             ("testUserDefinedCloseCode", testUserDefinedCloseCode),
             ("testUserCloseMessage", testUserCloseMessage)
@@ -261,6 +262,17 @@ class BasicTests: KituraTest {
                                  expectedFrames: [(true, self.opcodeText, textPayload)],
                                  expectation: expectation, negotiateCompression: true, compressed: false)
             })
+    }
+
+    func testTextShortMessageWithQueryParams() {
+        register(closeReason: .noReasonCodeSent, testQueryParams: true)
+        let textPayload = self.payload(text: "Keys and Values: ")
+        let expectedPayload = self.payload(text: "Keys and Values: p1,p2 and v1,v2")
+        performServerTest(asyncTasks: { expectation in
+            self.performTest(onPath: "/wstester?p1=v1&p2=v2", framesToSend: [(true, self.opcodeText, textPayload)],
+                             expectedFrames: [(true, self.opcodeText, expectedPayload)],
+                             expectation: expectation)
+        })
     }
 
     func testUserDefinedCloseCode() {

--- a/Tests/KituraWebSocketTests/KituraTest.swift
+++ b/Tests/KituraWebSocketTests/KituraTest.swift
@@ -77,12 +77,12 @@ class KituraTest: XCTestCase {
         }
     }
 
-    func performTest(framesToSend: [(Bool, Int, NSData)], masked: [Bool] = [],
+    func performTest(onPath: String? = nil, framesToSend: [(Bool, Int, NSData)], masked: [Bool] = [],
                      expectedFrames: [(Bool, Int, NSData)], expectation: XCTestExpectation,
                      negotiateCompression: Bool = false, compressed: Bool = false) {
         precondition(masked.count == 0 || framesToSend.count == masked.count)
         let upgraded = DispatchSemaphore(value: 0)
-        guard let channel = sendUpgradeRequest(toPath: servicePath, usingKey: secWebKey, semaphore: upgraded, negotiateCompression: negotiateCompression) else { return }
+        guard let channel = sendUpgradeRequest(toPath: onPath ?? servicePath, usingKey: secWebKey, semaphore: upgraded, negotiateCompression: negotiateCompression) else { return }
         upgraded.wait()
         do {
             _ = try channel.pipeline.removeHandler(httpRequestEncoder!).wait()
@@ -99,8 +99,8 @@ class KituraTest: XCTestCase {
         }
     }
 
-    func register(onPath: String? = nil, closeReason: WebSocketCloseReasonCode, testServerRequest: Bool = false, pingMessage: String? = nil) {
-        let service = TestWebSocketService(closeReason: closeReason, testServerRequest: testServerRequest, pingMessage: pingMessage)
+    func register(onPath: String? = nil, closeReason: WebSocketCloseReasonCode, testServerRequest: Bool = false, pingMessage: String? = nil, testQueryParams: Bool = false) {
+        let service = TestWebSocketService(closeReason: closeReason, testServerRequest: testServerRequest, pingMessage: pingMessage, testQueryParams: testQueryParams)
         WebSocket.register(service: service, onPath: onPath ?? servicePath)
     }
 
@@ -194,11 +194,14 @@ class HTTPResponseHandler: ChannelInboundHandler {
             if let errorMessage = errorMessage {
                 KituraTest.checkUpgradeFailureResponse(statusCode, errorMessage)
             } else {
-                KituraTest.checkUpgradeResponse(statusCode, secWebSocketAccept[0], key)
-                upgradeDoneOrRefused.signal()
+                XCTAssertEqual(secWebSocketAccept.count, 1, "Upgrade to WebSocket failed")
+                if secWebSocketAccept.count > 0 {
+                    KituraTest.checkUpgradeResponse(statusCode, secWebSocketAccept[0], key)
+                    upgradeDoneOrRefused.signal()
+                }
             }
         case .body(let buffer):
-            XCTAssertEqual(buffer.getString(at: 0, length: buffer.readableBytes) ?? "", errorMessage!)
+            XCTAssertEqual(buffer.getString(at: 0, length: buffer.readableBytes) ?? "", errorMessage ?? "No error message")
             upgradeDoneOrRefused.signal()
         default: break
         }


### PR DESCRIPTION
This tests the ability of Kitura-NIO to ignore query paramters and route
control to the appropriate WebSocket service.