### PR TITLE
permessage-deflate: implement context takeover

### DIFF
--- a/Sources/KituraWebSocket/PermessageDeflate.swift
+++ b/Sources/KituraWebSocket/PermessageDeflate.swift
@@ -26,9 +26,8 @@ class PermessageDeflate: WebSocketProtocolExtension {
         guard header.hasPrefix("permessage-deflate") else { return [] }
         var deflaterMaxWindowBits: Int32 = 15
         var inflaterMaxWindowBits: Int32 = 15
-        //TODO: change these defaults to false after implementing context takeover
-        var clientNoContextTakeover = true
-        var serverNoContextTakeover = true
+        var clientNoContextTakeover = false
+        var serverNoContextTakeover = false
 
         // Four parameters to handle:
         // * server_max_window_bits: the LZ77 sliding window size used by the server for compression
@@ -66,7 +65,6 @@ class PermessageDeflate: WebSocketProtocolExtension {
                 serverNoContextTakeover = true
             }
         }
-
         return [PermessageDeflateCompressor(maxWindowBits: deflaterMaxWindowBits, noContextTakeOver: serverNoContextTakeover),
                    PermessageDeflateDecompressor(maxWindowBits: inflaterMaxWindowBits, noContextTakeOver: clientNoContextTakeover)]
     }
@@ -81,16 +79,13 @@ class PermessageDeflate: WebSocketProtocolExtension {
 
         for parameter in header.components(separatedBy: "; ") {
             if parameter == "client_no_context_takeover" {
-                //TODO: include client_no_context_takeover in the response
+                response.append("; client_no_context_takeover")
             }
 
             if parameter == "server_no_context_takeover" {
-                //TODO: include server_no_context_takeover in the response
+                response.append("; server_no_context_takeover")
             }
         }
-        //TODO: remove this after we have implemented context takeover
-        response.append("; server_no_context_takeover")
-        response.append("; client_no_context_takeover")
         return response
     }
 }

--- a/Sources/KituraWebSocket/PermessageDeflate.swift
+++ b/Sources/KituraWebSocket/PermessageDeflate.swift
@@ -35,25 +35,35 @@ class PermessageDeflate: WebSocketProtocolExtension {
         // * server_no_context_takeover: prevent the server from using context-takeover
         // * client_no_context_takeover: prevent the client from using context-takeover
         for parameter in header.components(separatedBy: "; ") {
-            // If we receieved a valid value for server_max_window_bits, configure the deflater to use it
+            // If we receieved a valid value for server_max_window_bits, use it to configure the deflater
             if parameter.hasPrefix("server_max_window_bits") {
                 let maxWindowBits = parameter.components(separatedBy: "=")
                 guard maxWindowBits.count == 2 else { continue }
-                if let mwBits = Int32(maxWindowBits[1]) {
-                    if mwBits >= 8 && mwBits <= 15 {
-                        deflaterMaxWindowBits = mwBits
-                    }
+                guard let mwBits = Int32(maxWindowBits[1]) else { continue }
+                if mwBits >= 8 && mwBits <= 15 {
+                    // We received a valid value. However there's a special case here:
+                    //
+                    // There's an open zlib issue which does not set the window size
+                    // to 256 (windowBits=8). For windowBits=8, zlib silently changes the
+                    // value to 9. However, this apparent hack works only with zlib streams.
+                    // WebSockets use raw deflate streams. For raw deflate streams, zlib has been
+                    // patched to ignore the windowBits value 8.
+                    // More details here: https://github.com/madler/zlib/issues/171
+                    //
+                    // So, if the server requested for server_max_window_bits=8, we are
+                    // going to use server_max_window_bits=9 instead and notify this in
+                    // our negotiation response too.
+                    deflaterMaxWindowBits = mwBits == 8 ? 9 : mwBits
                 }
             }
 
-            // If we receieved a valid value for server_max_window_bits, configure the inflater to use it
+            // If we received a valid client_max_window_bits value, use it to configure the inflater
             if parameter.hasPrefix("client_max_window_bits") {
                 let maxWindowBits = parameter.components(separatedBy: "=")
                 guard maxWindowBits.count == 2 else { continue }
-                if let mwBits = Int32(maxWindowBits[1]) {
-                    if mwBits >= 8 && mwBits <= 15  {
-                        inflaterMaxWindowBits = mwBits
-                    }
+                guard let mwBits = Int32(maxWindowBits[1]) else { continue }
+                if mwBits >= 8 && mwBits <= 15  {
+                    inflaterMaxWindowBits = mwBits
                 }
             }
 
@@ -84,6 +94,37 @@ class PermessageDeflate: WebSocketProtocolExtension {
 
             if parameter == "server_no_context_takeover" {
                 response.append("; server_no_context_takeover")
+            }
+
+            // If we receive a valid value for server_max_window_bits, we accept it and return if
+            // in the response. If we receive an invalid value, we default to 15 and return the
+            // same in the response. If we receive no value, we ignore this header.
+            if parameter.hasPrefix("server_max_window_bits") {
+                let maxWindowBits = parameter.components(separatedBy: "=")
+                guard maxWindowBits.count == 2 else { continue }
+                guard let mwBits = Int32(maxWindowBits[1]) else { continue }
+                if mwBits >= 8 && mwBits <= 15 {
+                    // We received a valid value. However there's a special case here:
+                    //
+                    // There's an open zlib issue which does not set the window size
+                    // to 256 (windowBits=8). For windowBits=8, zlib silently changes the
+                    // value to 9. However, this apparent hack works only with zlib streams.
+                    // WebSockets use raw deflate streams. For raw deflate streams, zlib has been
+                    // patched to ignore the windowBits value 8.
+                    // More details here: https://github.com/madler/zlib/issues/171
+                    //
+                    // So, if the server requested for server_max_window_bits=8, we are
+                    // going to use server_max_window_bits=9 instead and notify this in
+                    // our negotiation response too.
+                    if mwBits == 8 {
+                        response.append("; server_max_window_bits=9")
+                    } else {
+                        response.append("; \(parameter)")
+                    }
+                } else {
+                    // we received an invalid value
+                    response.append("; server_max_window_bits=15")
+                }
             }
         }
         return response

--- a/Sources/KituraWebSocket/PermessageDeflateCompressor.swift
+++ b/Sources/KituraWebSocket/PermessageDeflateCompressor.swift
@@ -80,23 +80,36 @@ class PermessageDeflateCompressor : ChannelOutboundHandler {
         _ = context.writeAndFlush(self.wrapOutboundOut(deflatedFrame))
     }
 
+    func close(context: ChannelHandlerContext, mode: CloseMode, promise: EventLoopPromise<Void>?) {
+        // PermessageDeflateCompressor is an outbound handler. If the underlying
+        // WebSocketConnection decides to close the connection, the close message
+        // needs to be intercepted and the deflater closed while we're using context takeover.
+        if noContextTakeOver == false {
+            deflateEnd(&stream)
+        }
+        context.close(mode: mode, promise: promise)
+    }
+
     func deflatePayload(in buffer: ByteBuffer, allocator: ByteBufferAllocator, dropFourTrailingOctets: Bool = false) -> ByteBuffer {
         // Initialize the deflater as per https://www.zlib.net/zlib_how.html
         if noContextTakeOver || streamInitialized == false {
             stream.zalloc = nil
             stream.zfree = nil
             stream.opaque = nil
+            stream.next_in = nil
+            stream.avail_in = 0
+            // The zlib manual asks us to provide a negative windowBits value for raw deflate
+            let rc = deflateInit2_(&stream, Z_DEFAULT_COMPRESSION, Z_DEFLATED, -self.maxWindowBits, 8,
+                                   Z_DEFAULT_STRATEGY, ZLIB_VERSION, Int32(MemoryLayout<z_stream>.size))
+            precondition(rc == Z_OK, "Unexpected return from zlib init: \(rc)")
             self.streamInitialized = true
         }
 
-        // The zlib manual asks us to provide a negative windowBits value for raw deflate
-        let rc = deflateInit2_(&stream, Z_DEFAULT_COMPRESSION, Z_DEFLATED, -self.maxWindowBits, 8,
-                     Z_DEFAULT_STRATEGY, ZLIB_VERSION, Int32(MemoryLayout<z_stream>.size))
-        precondition(rc == Z_OK, "Unexpected return from zlib init: \(rc)")
-
         defer {
-            // Deinitialize the deflater before returning
             if noContextTakeOver {
+                // We aren't doing a context takeover.
+                // This means the deflater is to be used on a per-message basis.
+                // So, we deinitialize the deflater before returning.
                 deflateEnd(&stream)
             }
         }

--- a/Sources/KituraWebSocket/WebSocketConnection.swift
+++ b/Sources/KituraWebSocket/WebSocketConnection.swift
@@ -335,10 +335,10 @@ extension WebSocketConnection {
          let frame = WebSocketFrame(fin: true, opcode: .connectionClose, data: data)
          let promise = context.eventLoop.makePromise(of: Void.self)
          context.writeAndFlush(self.wrapOutboundOut(frame), promise: promise)
-         promise.futureResult.whenComplete { _ in
-             if hard {
-                 _ = context.close(mode: .output)
-             }
+         if hard {
+            promise.futureResult.flatMap { _ in
+                context.close(mode: .output)
+            }.whenComplete { _ in }
          }
          awaitClose = true
     }

--- a/Tests/KituraWebSocketTests/ComplexTests.swift
+++ b/Tests/KituraWebSocketTests/ComplexTests.swift
@@ -29,7 +29,11 @@ class ComplexTests: KituraTest {
             ("testPingBetweenBinaryFrames", testPingBetweenBinaryFrames),
             ("testPingBetweenTextFrames", testPingBetweenTextFrames),
             ("testTextShortAndMediumFrames", testTextShortAndMediumFrames),
-            ("testTextTwoShortFrames", testTextTwoShortFrames)
+            ("testTextTwoShortFrames", testTextTwoShortFrames),
+            ("testTwoMessagesWithContextTakeover", testTwoMessagesWithContextTakeover),
+            ("testTwoMessagesWithClientContextTakeover", testTwoMessagesWithClientContextTakeover),
+            ("testTwoMessagesWithServerContextTakeover", testTwoMessagesWithServerContextTakeover),
+            ("testTwoMessagesWithNoContextTakeover", testTwoMessagesWithNoContextTakeover),
         ]
     }
 
@@ -58,7 +62,7 @@ class ComplexTests: KituraTest {
                 self.performTest(framesToSend: [(false, self.opcodeBinary, shortBinaryPayload), (true, self.opcodeContinuation, mediumBinaryPayload)],
                                  expectedFrames: [(true, self.opcodeBinary, expectedBinaryPayload)],
                                  expectation: expectation, negotiateCompression: true, compressed: true)
-            },  { expectation in
+            }, { expectation in
                 self.performTest(framesToSend: [(false, self.opcodeBinary, shortBinaryPayload), (true, self.opcodeContinuation, mediumBinaryPayload)],
                                  expectedFrames: [(true, self.opcodeBinary, expectedBinaryPayload)],
                                  expectation: expectation, negotiateCompression: true, compressed: false)
@@ -182,5 +186,34 @@ class ComplexTests: KituraTest {
                                  expectedFrames: [(true, self.opcodeText, textExpectedPayload)],
                                  expectation: expectation, negotiateCompression: true, compressed: false)
         })
+    }
+
+    func testTwoMessages(contextTakeover: ContextTakeover = .both) {
+        register(closeReason: .noReasonCodeSent)
+
+        let text = "RFC7692 specifies a framework for adding compression functionality to the WebSocket Protocol"
+        let textPayload = self.payload(text: text)
+
+        performServerTest(asyncTasks: { expectation in
+            self.performTest(framesToSend: [(true, self.opcodeText, textPayload), (true, self.opcodeText, textPayload)],
+                             expectedFrames: [(true, self.opcodeText, textPayload), (true, self.opcodeText, textPayload)],
+                             expectation: expectation, negotiateCompression: true, compressed: true, contextTakeover: contextTakeover)
+        })
+    }
+
+    func testTwoMessagesWithContextTakeover() {
+        testTwoMessages(contextTakeover: .both)
+    }
+
+    func testTwoMessagesWithClientContextTakeover() {
+        testTwoMessages(contextTakeover: .client)
+    }
+
+    func testTwoMessagesWithServerContextTakeover() {
+        testTwoMessages(contextTakeover: .server)
+    }
+
+    func testTwoMessagesWithNoContextTakeover() {
+        testTwoMessages(contextTakeover: .none)
     }
 }

--- a/Tests/KituraWebSocketTests/KituraTest.swift
+++ b/Tests/KituraWebSocketTests/KituraTest.swift
@@ -27,6 +27,30 @@ import Foundation
 import Dispatch
 import LoggerAPI
 
+enum ContextTakeover {
+    case none
+    case client
+    case server
+    case both
+
+    func header() -> String {
+        switch self {
+        case .none: return "client_no_context_takeover; server_no_context_takeover"
+        case .client: return "server_no_context_takeover"
+        case .server: return "client_no_context_takeover"
+        case .both: return ""
+        }
+    }
+
+    var clientNoContextTakeover: Bool {
+        return self != .client && self != .both
+    }
+
+    var serverNoContextTakeover: Bool {
+        return self != .server || self != .both
+    }
+}
+
 class KituraTest: XCTestCase {
 
     private static let initOnce: () = {
@@ -46,11 +70,13 @@ class KituraTest: XCTestCase {
     let servicePathNoSlash = "wstester"
     let servicePath = "/wstester"
 
-    var  httpRequestEncoder: HTTPRequestEncoder?
+    var httpRequestEncoder: HTTPRequestEncoder?
 
     var httpResponseDecoder: ByteToMessageHandler<HTTPResponseDecoder>?
 
     var httpHandler: HTTPResponseHandler?
+
+    var compressor: PermessageDeflateCompressor = PermessageDeflateCompressor()
 
     func performServerTest(line: Int = #line, asyncTasks: (XCTestExpectation) -> Void...) {
         let server = HTTP.createServer()
@@ -79,23 +105,25 @@ class KituraTest: XCTestCase {
 
     func performTest(onPath: String? = nil, framesToSend: [(Bool, Int, NSData)], masked: [Bool] = [],
                      expectedFrames: [(Bool, Int, NSData)], expectation: XCTestExpectation,
-                     negotiateCompression: Bool = false, compressed: Bool = false) {
+                     negotiateCompression: Bool = false, compressed: Bool = false, contextTakeover: ContextTakeover? = nil) {
         precondition(masked.count == 0 || framesToSend.count == masked.count)
         let upgraded = DispatchSemaphore(value: 0)
-        guard let channel = sendUpgradeRequest(toPath: onPath ?? servicePath, usingKey: secWebKey, semaphore: upgraded, negotiateCompression: negotiateCompression) else { return }
+        self.compressor = PermessageDeflateCompressor(noContextTakeOver: contextTakeover?.clientNoContextTakeover ?? false)
+        let decompressor = PermessageDeflateDecompressor(noContextTakeOver: contextTakeover?.serverNoContextTakeover ?? false)
+        guard let channel = sendUpgradeRequest(toPath: onPath ?? servicePath, usingKey: secWebKey, semaphore: upgraded, negotiateCompression: negotiateCompression, contextTakeover: contextTakeover) else { return }
         upgraded.wait()
         do {
             _ = try channel.pipeline.removeHandler(httpRequestEncoder!).wait()
             _ = try channel.pipeline.removeHandler(httpResponseDecoder!).wait()
             _ = try channel.pipeline.removeHandler(httpHandler!).wait()
-            try channel.pipeline.addHandler(WebSocketClientHandler(expectedFrames: expectedFrames, expectation: expectation, compressed: negotiateCompression), position: .first).wait()
+            try channel.pipeline.addHandler(WebSocketClientHandler(expectedFrames: expectedFrames, expectation: expectation, compressed: negotiateCompression, decompressor: decompressor), position: .first).wait()
         } catch let error {
            Log.error("Error: \(error)")
         }
         for idx in 0..<framesToSend.count {
             let masked = masked.count == 0 ? true : masked[idx]
             let (finalToSend, opCodeToSend, payloadToSend) = framesToSend[idx]
-            self.sendFrame(final: finalToSend, withOpcode: opCodeToSend, withMasking: masked, withPayload: payloadToSend, on: channel, lastFrame: idx == framesToSend.count-1, compressed: compressed)
+            self.sendFrame(final: finalToSend, withOpcode: opCodeToSend, withMasking: masked, withPayload: payloadToSend, on: channel, lastFrame: idx == framesToSend.count-1, compressed: compressed, contextTakeover: contextTakeover)
         }
     }
 
@@ -112,7 +140,7 @@ class KituraTest: XCTestCase {
         }
     }
 
-    func sendUpgradeRequest(forProtocolVersion: String? = "13", toPath: String, usingKey: String?, semaphore: DispatchSemaphore, errorMessage: String? = nil, negotiateCompression: Bool = false) -> Channel? {
+    func sendUpgradeRequest(forProtocolVersion: String? = "13", toPath: String, usingKey: String?, semaphore: DispatchSemaphore, errorMessage: String? = nil, negotiateCompression: Bool = false, contextTakeover: ContextTakeover? = nil ) -> Channel? {
         self.httpHandler = HTTPResponseHandler(key: usingKey ?? "", semaphore: semaphore, errorMessage: errorMessage)
         let clientBootstrap = ClientBootstrap(group: MultiThreadedEventLoopGroup(numberOfThreads: 1))
             .channelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEPORT), value: 1)
@@ -132,7 +160,11 @@ class KituraTest: XCTestCase {
                 headers.add(name: "Sec-WebSocket-Key", value: key)
             }
             if negotiateCompression {
-                headers.add(name: "Sec-WebSocket-Extensions", value: "permessage-deflate")
+                var value = "permessage-deflate"
+                if let contextTakeover = contextTakeover {
+                   value.append("; \(contextTakeover.header())")
+                }
+                headers.add(name: "Sec-WebSocket-Extensions", value: value)
             }
             request.headers = headers
             channel.write(NIOAny(HTTPClientRequestPart.head(request)), promise: nil)

--- a/Tests/KituraWebSocketTests/KituraTest.swift
+++ b/Tests/KituraWebSocketTests/KituraTest.swift
@@ -47,7 +47,7 @@ enum ContextTakeover {
     }
 
     var serverNoContextTakeover: Bool {
-        return self != .server || self != .both
+        return self != .server && self != .both
     }
 }
 


### PR DESCRIPTION
This is an an implementation of context takeover. 

For every WebSocket connection on which compression using permessage-deflate is negotiated, we configure a compressor and a decompressor on the channel pipeline. Context takeover is then implemented as:

1. If the client requests for "no client context takeover", we agree. The decompressor reuses context otherwise.
2. If the client requests for "no server context takeover", we agree. The compressor reuses the context otherwise.
3. A context reuse implies reusing the wrapped zlib stream without initialising it.
4. A context reuse also implies the wrapped zlib stream is never deinitialized. 