### PR TITLE
Correct the checks that trigger decompression

### DIFF
--- a/Sources/KituraWebSocket/PermessageDeflateCompressor.swift
+++ b/Sources/KituraWebSocket/PermessageDeflateCompressor.swift
@@ -49,7 +49,7 @@ class PermessageDeflateCompressor : ChannelOutboundHandler {
         var frame = unwrapOutboundIn(data)
 
         // If this is a control frame, do not attempt compression.
-        guard frame.isDataFrame else {
+        guard frame.isDataFrame || frame.isContinuationFrame else {
              context.writeAndFlush(self.wrapOutboundOut(frame)).whenComplete { _ in
                  promise?.succeed(())
              }


### PR DESCRIPTION
The change introduced in pull request #18 made two wrong checks while deciding
if a received frame has compressed data and must undergo decompression.

First, we included continuation frames in the concept of a `data frame`. RFC6455
clearly defines data frames as either text or binary frames, and continuation
frames aren't treated as data frames, though they carry fragmented data.

Secondly, RFC7692 clearly states that a message whose first fragment has rsv1
set is considered as a compressed message. This implies that the continuation
frames which carry subsequent fragments of a compressed message need not have
rsv1 set.

Overall, a frame is considered to be compressed if:
1. It is a data frame and has rsv1 set
2. It is a continuation frame received after a compressed data frame