### PR TITLE
Remove a retain cycle

### DIFF
--- a/Sources/KituraWebSocket/WebSocketConnection.swift
+++ b/Sources/KituraWebSocket/WebSocketConnection.swift
@@ -41,7 +41,7 @@ public class WebSocketConnection {
 
     var message: ByteBuffer?
 
-    var context: ChannelHandlerContext?
+    weak var context: ChannelHandlerContext?
 
     private var errors: [String] = []
 


### PR DESCRIPTION
WebSocketConnection holds a strong reference to the ChannelHandlerContext,
using which it invokes all the channel operations. WebSocktConnection is also a
ChannelInboundHandler and so the ChannelHandlerContext also holds a strong
reference to it. This retain cycle ends up in a memory leak, which can be quite
serious because the ByteBuffers that hold application data are also referenced
from the WebSocketConnection. A WebSocketConnection cannot exist without the
underlying Channel. So, it makes sense for WebSocketConnection to hold a weak
reference to the ChannelHandlerContext.