### PR TITLE
Don't log errors on detecting closed channels

### DIFF
--- a/Sources/KituraWebSocket/WebSocketConnection.swift
+++ b/Sources/KituraWebSocket/WebSocketConnection.swift
@@ -37,8 +37,6 @@ public class WebSocketConnection {
 
     var awaitClose = false
 
-    var active = true
-
     var message: ByteBuffer?
 
     weak var context: ChannelHandlerContext?
@@ -58,7 +56,6 @@ public class WebSocketConnection {
     }
 
     public func ping(withMessage: String? = nil) {
-        guard active else { return }
         guard let context = context else {
             return
         }
@@ -75,7 +72,6 @@ public class WebSocketConnection {
     }
 
     public func send(message: Data, asBinary: Bool = true) {
-        guard active else { return }
         guard let context = context else {
             return
         }
@@ -87,7 +83,6 @@ public class WebSocketConnection {
     }
 
     public func send(message: String) {
-        guard active else { return }
         guard let context = context else {
             return
         }
@@ -198,7 +193,7 @@ extension WebSocketConnection: ChannelInboundHandler {
             }
 
         case .connectionClose:
-            if active {
+            if context != nil {
                 let reasonCode: WebSocketErrorCode
                 var description: String?
                 if frame.length >= 2 && frame.length < 126 {

--- a/Sources/KituraWebSocket/WebSocketConnection.swift
+++ b/Sources/KituraWebSocket/WebSocketConnection.swift
@@ -60,7 +60,6 @@ public class WebSocketConnection {
     public func ping(withMessage: String? = nil) {
         guard active else { return }
         guard let context = context else {
-            Log.error("ChannelHandlerContext unavailable")
             return
         }
         context.eventLoop.execute {
@@ -78,7 +77,6 @@ public class WebSocketConnection {
     public func send(message: Data, asBinary: Bool = true) {
         guard active else { return }
         guard let context = context else {
-            Log.error("ChannelHandlerContext unavailable")
             return
         }
         context.eventLoop.execute {
@@ -91,7 +89,6 @@ public class WebSocketConnection {
     public func send(message: String) {
         guard active else { return }
         guard let context = context else {
-            Log.error("ChannelHandlerContext unavailable")
             return
         }
         context.eventLoop.execute {
@@ -291,7 +288,6 @@ extension WebSocketConnection {
 
     func connectionClosed(reason: WebSocketErrorCode, description: String? = nil, reasonToSendBack: WebSocketErrorCode? = nil) {
         guard let context = context else {
-             Log.error("ChannelHandlerContext unavailable")
              return
         }
         if context.channel.isWritable {
@@ -304,7 +300,6 @@ extension WebSocketConnection {
 
     func sendMessage(with opcode: WebSocketOpcode, data: ByteBuffer) {
         guard let context = context else {
-            Log.error("ChannelHandlerContext unavailable")
             return
         }
         guard context.channel.isWritable else {
@@ -323,7 +318,6 @@ extension WebSocketConnection {
 
     func closeConnection(reason: WebSocketErrorCode?, description: String?, hard: Bool) {
          guard let context = context else {
-             Log.error("ChannelHandlerContext unavailable")
              return
          }
          var data = context.channel.allocator.buffer(capacity: 2)


### PR DESCRIPTION
With `WebSocketConnection` being changed to hold only a weak reference
to `ChannelHandlerContext`, the reference changes to a nil when the
underlying Channel is closed by the client. This does not qualify to
be an error condition and we should not log error messages here.