### PR TITLE
Add automatic stale connection cleanup

### DIFF
--- a/Sources/KituraWebSocket/WSConnectionUpgradeFactory.swift
+++ b/Sources/KituraWebSocket/WSConnectionUpgradeFactory.swift
@@ -36,7 +36,7 @@ public class WSConnectionUpgradeFactory: ProtocolHandlerFactory {
         let wsRequest = WSServerRequest(request: request)
         let service = registry[wsRequest.urlURL.path]
 
-        let connection = WebSocketConnection(request: wsRequest)
+        let connection = WebSocketConnection(request: wsRequest, service: service)
         connection.service = service
 
         return connection

--- a/Sources/KituraWebSocket/WebSocketConnection.swift
+++ b/Sources/KituraWebSocket/WebSocketConnection.swift
@@ -252,7 +252,11 @@ extension WebSocketConnection: ChannelInboundHandler {
     }
 
     public func userInboundEventTriggered(context: ChannelHandlerContext, event: Any) {
-        guard event is IdleStateHandler.IdleStateEvent else { return }
+        guard event is IdleStateHandler.IdleStateEvent else {
+            context.fireUserInboundEventTriggered(event)
+            return
+        }
+
         if self.waitingForPong {
             _ = context.channel.close(mode: .all)
         } else {

--- a/Sources/KituraWebSocket/WebSocketConnection.swift
+++ b/Sources/KituraWebSocket/WebSocketConnection.swift
@@ -43,8 +43,15 @@ public class WebSocketConnection {
 
     private var errors: [String] = []
 
-    init(request: ServerRequest) {
+    // A connection timeout configured by the WebSocketService
+    private let connectionTimeout: Int?
+
+    // Are we waiting for a pong in response to a heartbeat ping?
+    private var waitingForPong: Bool = false
+
+    init(request: ServerRequest, service: WebSocketService? = nil) {
         self.request = request
+        self.connectionTimeout = service?.connectionTimeout
     }
 
     public func close(reason: WebSocketCloseReasonCode? = nil, description: String? = nil) {
@@ -101,6 +108,10 @@ extension WebSocketConnection: ChannelInboundHandler {
     public func handlerAdded(context: ChannelHandlerContext) {
         self.context = context
         guard context.channel.isActive else { return }
+        if let timeout = self.connectionTimeout {
+            let idleStateHandler = IdleStateHandler(allTimeout: TimeAmount.seconds(Int64(timeout/2)))
+            context.pipeline.addHandler(idleStateHandler, position: .before(self)).whenComplete { _ in }
+        }
         self.fireConnected()
     }
 
@@ -224,7 +235,11 @@ extension WebSocketConnection: ChannelInboundHandler {
             }
             sendMessage(with: .pong, data: data)
 
-        case .pong: break
+        case .pong:
+            // If we were expecting this pong, following a heartbeat ping, don't expect it anymore.
+            if self.waitingForPong {
+                self.waitingForPong = false
+            }
 
         case let code where code.isControlOpcode:
             let intCode = Int(webSocketOpcode: code)
@@ -233,6 +248,16 @@ extension WebSocketConnection: ChannelInboundHandler {
         case let code:
             let intCode = Int(webSocketOpcode: code)
             closeConnection(reason: .protocolError, description: "Parsed a frame with an invalid operation code of \(intCode)", hard: true)
+        }
+    }
+
+    public func userInboundEventTriggered(context: ChannelHandlerContext, event: Any) {
+        guard event is IdleStateHandler.IdleStateEvent else { return }
+        if self.waitingForPong {
+            _ = context.channel.close(mode: .all)
+        } else {
+            self.sendMessage(with: .ping, data: context.channel.allocator.buffer(capacity: 2))
+            self.waitingForPong = true
         }
     }
 

--- a/Sources/KituraWebSocket/WebSocketService.swift
+++ b/Sources/KituraWebSocket/WebSocketService.swift
@@ -16,14 +16,47 @@
 
 import Foundation
 
+/// The `WebSocketService` protocol is implemented by classes that wish to be WebSocket server side
+/// end points. An instance of the `WebSocketService` protocol is the server side of a WebSocket connection.
+/// There can be many WebSocket connections connected to a single `WebSocketService` protocol instance.
+/// The protocol is a set of callbacks that are invoked when various events occur.
 public protocol WebSocketService: class {
 
+    /// Called when a WebSocket client connects to the server and is connected to a specific
+    /// `WebSocketService`.
+    ///
+    /// - Parameter connection: The `WebSocketConnection` object that represents the client's
+    ///
     func connected(connection: WebSocketConnection)
 
+    /// Called when a WebSocket client disconnects from the server.
+    ///
+    /// - Parameter connection: The `WebSocketConnection` object that represents the connection that
+    ///                    was disconnected from this `WebSocketService`.
+    /// - Parameter reason: The `WebSocketCloseReasonCode` that describes why the client disconnected.
     func disconnected(connection: WebSocketConnection, reason: WebSocketCloseReasonCode)
 
+    /// Called when a WebSocket client sent a binary message to the server to this `WebSocketService`.
+    ///
+    /// - Parameter message: A Data struct containing the bytes of the binary message sent by the client.
+    /// - Parameter client: The `WebSocketConnection` object that represents the connection over which
+    ///                     the client sent the message to this `WebSocketService`
     func received(message: Data, from: WebSocketConnection)
 
+    /// Called when a WebSocket client sent a text message to the server to this `WebSocketService`.
+    ///
+    /// - Parameter message: A String containing the text message sent by the client.
+    /// - Parameter client: The `WebSocketConnection` object that represents the connection over which
+    ///                     the client sent the message to this `WebSocketService`
     func received(message: String, from: WebSocketConnection)
 
+    /// The time in seconds that a connection must be unresponsive to be automatically closed by the server. If the WebSocket server has not received any messages in the first half of the timeout time it will ping the connection. If a pong is not received in the remaining half of the timeout, the connection will be closed with a 1006 (connection closed abnormally) status code. The `connectionTimeout` defaults to `nil`, meaning no connection cleanup will take place.
+    var connectionTimeout: Int? { get }
+}
+
+extension WebSocketService {
+    /// Default computed value for `connectionTimeout` that returns `nil`.
+    var connectionTimeout: Int? {
+        return nil
+    }
 }

--- a/Sources/TestWebSocketService/main.swift
+++ b/Sources/TestWebSocketService/main.swift
@@ -33,6 +33,8 @@ class EchoService: WebSocketService {
     public func received(message: String, from: WebSocketConnection) {
         from.send(message: message)
     }
+
+    public let connectionTimeout: Int? = 20
 }
 
 WebSocket.register(service: EchoService(), onPath: "/")

--- a/Tests/KituraWebSocketTests/ConnectionCleanupTests.swift
+++ b/Tests/KituraWebSocketTests/ConnectionCleanupTests.swift
@@ -1,0 +1,116 @@
+/*
+ * Copyright IBM Corporation 2019
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import XCTest
+import Foundation
+
+import NIO
+import NIOWebSocket
+
+
+class ConnectionCleanupTests: KituraTest {
+
+    static var allTests: [(String, (ConnectionCleanupTests) -> () throws -> Void)] {
+        return [
+            ("testNilConnectionTimeOut", testNilConnectionTimeOut),
+            ("testSingleConnectionTimeOut", testSingleConnectionTimeOut),
+            ("testPingKeepsConnectionAlive", testPingKeepsConnectionAlive),
+            ("testMultiConnectionTimeOut", testMultiConnectionTimeOut),
+        ]
+    }
+
+    func testNilConnectionTimeOut() {
+        register(closeReason: .noReasonCodeSent)
+        performServerTest { expectation in
+            let _client = WebSocketClient(host: "localhost", port: 8080,
+                                         uri: "/wstester", requestKey: "test")
+            guard let client = _client else {
+                XCTFail("Couldn't create a WebSocket connection")
+                return
+            }
+            sleep(2)
+            XCTAssertTrue(client.isConnected)
+            expectation.fulfill()
+        }
+    }
+
+    func testSingleConnectionTimeOut() {
+        register(closeReason: .noReasonCodeSent, connectionTimeout: 2)
+        performServerTest { expectation in
+            let _client = WebSocketClient(host: "localhost", port: 8080,
+                                         uri: "/wstester", requestKey: "test")
+            guard let client = _client else {
+                XCTFail("Couldn't create a WebSocket connection")
+                return
+            }
+            sleep(4)
+            XCTAssertFalse(client.isConnected)
+            expectation.fulfill()
+        }
+    }
+
+    func testPingKeepsConnectionAlive() {
+        register(closeReason: .noReasonCodeSent, connectionTimeout: 2)
+        performServerTest { expectation in
+            let _client = WebSocketClient(host: "localhost", port: 8080,
+                                         uri: "/wstester", requestKey: "test")
+            guard let client = _client else {
+                XCTFail("Couldn't create a WebSocket connection")
+                return
+            }
+
+            client.onPing = { data in
+                client.pong(data: data)
+            }
+
+            sleep(4)
+            XCTAssertTrue(client.isConnected)
+            expectation.fulfill()
+        }
+    }
+
+    func testMultiConnectionTimeOut() {
+        register(closeReason: .noReasonCodeSent, connectionTimeout: 2)
+
+        performServerTest { expectation in
+            let _client1 = WebSocketClient(host: "localhost",
+                                          port: 8080,
+                                          uri: "/wstester",
+                                          requestKey: "test")
+            guard let client1 = _client1 else {
+                XCTFail("Couldn't establish a WebSocket connection with the server")
+                return
+            }
+
+            let _client2 = WebSocketClient(host: "localhost",
+                                                port: 8080,
+                                                uri: "/wstester",
+                                                requestKey: "test")
+            guard let client2 = _client2 else {
+                XCTFail("Couldn't create a WebSocket connection")
+                return
+            }
+
+            client2.onPing = { data in
+                client2.pong(data: data)
+            }
+
+            sleep(4)
+            XCTAssertFalse(client1.isConnected)
+            XCTAssertTrue(client2.isConnected)
+            expectation.fulfill()
+        }
+    }
+}

--- a/Tests/KituraWebSocketTests/KituraTest.swift
+++ b/Tests/KituraWebSocketTests/KituraTest.swift
@@ -105,7 +105,7 @@ class KituraTest: XCTestCase {
 
     func performTest(onPath: String? = nil, framesToSend: [(Bool, Int, NSData)], masked: [Bool] = [],
                      expectedFrames: [(Bool, Int, NSData)], expectation: XCTestExpectation,
-                     negotiateCompression: Bool = false, compressed: Bool = false, contextTakeover: ContextTakeover? = nil) {
+                     negotiateCompression: Bool = false, compressed: Bool = false, contextTakeover: ContextTakeover? = nil, sleepTime: Int = 0) {
         precondition(masked.count == 0 || framesToSend.count == masked.count)
         let upgraded = DispatchSemaphore(value: 0)
         self.compressor = PermessageDeflateCompressor(noContextTakeOver: contextTakeover?.clientNoContextTakeover ?? false)
@@ -127,8 +127,8 @@ class KituraTest: XCTestCase {
         }
     }
 
-    func register(onPath: String? = nil, closeReason: WebSocketCloseReasonCode, testServerRequest: Bool = false, pingMessage: String? = nil, testQueryParams: Bool = false) {
-        let service = TestWebSocketService(closeReason: closeReason, testServerRequest: testServerRequest, pingMessage: pingMessage, testQueryParams: testQueryParams)
+    func register(onPath: String? = nil, closeReason: WebSocketCloseReasonCode, testServerRequest: Bool = false, pingMessage: String? = nil, testQueryParams: Bool = false, connectionTimeout: Int? = nil) {
+        let service = TestWebSocketService(closeReason: closeReason, testServerRequest: testServerRequest, pingMessage: pingMessage, testQueryParams: testQueryParams, connectionTimeout: connectionTimeout)
         WebSocket.register(service: service, onPath: onPath ?? servicePath)
     }
 

--- a/Tests/KituraWebSocketTests/TestWebSocketService.swift
+++ b/Tests/KituraWebSocketTests/TestWebSocketService.swift
@@ -28,12 +28,15 @@ class TestWebSocketService: WebSocketService {
     let testQueryParams: Bool
     var queryParams: [String: String] = [:]
 
-    public init(closeReason: WebSocketCloseReasonCode, testServerRequest: Bool, pingMessage: String?, testQueryParams: Bool = false) {
+    public init(closeReason: WebSocketCloseReasonCode, testServerRequest: Bool, pingMessage: String?, testQueryParams: Bool = false, connectionTimeout: Int? = nil) {
         self.closeReason = closeReason
         self.testServerRequest = testServerRequest
         self.pingMessage = pingMessage
         self.testQueryParams = testQueryParams
+        self.connectionTimeout = connectionTimeout
     }
+
+    public let connectionTimeout: Int?
 
     public func connected(connection: WebSocketConnection) {
         connectionId = connection.id

--- a/Tests/KituraWebSocketTests/WebSocketClient.swift
+++ b/Tests/KituraWebSocketTests/WebSocketClient.swift
@@ -1,0 +1,158 @@
+/*
+ * Copyright IBM Corporation 2019
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+import NIO
+import NIOHTTP1
+import NIOWebSocket
+
+class WebSocketClient {
+
+    var httpClientHandler = HTTPClientHandler()
+    let requestKey: String
+    let host: String
+    let port: Int
+    let uri: String
+    var channel: Channel? = nil
+
+    public init?(host: String, port: Int, uri: String, requestKey: String, onOpen: @escaping (Channel?) -> Void = { _ in }) {
+        self.requestKey = requestKey
+        self.host = host
+        self.port = port
+        self.uri = uri
+        self.onOpen = onOpen
+        do {
+            try connect()
+        } catch {
+            return nil
+        }
+    }
+
+    public var isConnected: Bool {
+        return channel?.isActive ?? false
+    }
+
+    private func connect() throws {
+        let bootstrap = ClientBootstrap(group: MultiThreadedEventLoopGroup(numberOfThreads: 1))
+            .channelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEPORT), value: 1)
+            .channelInitializer(self.clientChannelInitializer)
+        let channel = try bootstrap.connect(host: self.host, port: self.port).wait()
+        var request = HTTPRequestHead(version: HTTPVersion.http11, method: .GET, uri: uri)
+        var headers = HTTPHeaders()
+        headers.add(name: "Host", value: "\(self.host):\(self.port)")
+        request.headers = headers
+        channel.write(NIOAny(HTTPClientRequestPart.head(request)), promise: nil)
+        _ = channel.writeAndFlush(NIOAny(HTTPClientRequestPart.end(nil)))
+        self.channel = channel
+    }
+
+    func clientChannelInitializer(channel: Channel)  -> EventLoopFuture<Void> {
+        let basicUpgrader = NIOWebClientSocketUpgrader(requestKey: "test") { channel, response in
+            self.onOpen(channel)
+            return channel.pipeline.addHandler(WebSocketMessageHandler(client: self))
+        }
+        let config: NIOHTTPClientUpgradeConfiguration = (upgraders: [basicUpgrader], completionHandler: { context in
+            context.channel.pipeline.removeHandler(self.httpClientHandler, promise: nil)
+        })
+        return channel.pipeline.addHTTPClientHandlers(withClientUpgrade: config).flatMap {
+            channel.pipeline.addHandler(self.httpClientHandler)
+        }
+    }
+
+    public func sendMessage(data: ByteBuffer) {
+        //Needs implementation
+    }
+
+    public func ping(data: ByteBuffer) {
+        //Needs implementation
+    }
+
+    public func pong(data: ByteBuffer) {
+        let frame = WebSocketFrame(fin: true, opcode: .pong, data: data)
+        guard let channel = channel else { return }
+        channel.writeAndFlush(frame, promise: nil)
+    }
+
+    public func close() {
+        //Needs implementation
+    }
+
+    // default, dummy callbacks
+    public var onOpen: (Channel) -> Void = { _ in }
+
+    public var onClose: (Channel) -> Void = { _ in }
+
+    public var onMessage: (ByteBuffer) -> Void = { _ in }
+
+    public var onPing: (ByteBuffer) -> Void = { _ in }
+
+    public var onPong: () -> Void = { }
+
+    public var onUpgradeFailure: (Channel) -> Void = { _ in }
+}
+
+class WebSocketMessageHandler: ChannelInboundHandler, RemovableChannelHandler {
+    typealias InboundIn = WebSocketFrame
+
+    private let client: WebSocketClient
+
+    private var buffer: ByteBuffer
+
+    public init(client: WebSocketClient) {
+        self.client = client
+        self.buffer = ByteBufferAllocator().buffer(capacity: 0)
+    }
+
+    private func unmaskedData(frame: WebSocketFrame) -> ByteBuffer {
+        var frameData = frame.data
+        if let maskingKey = frame.maskKey {
+            frameData.webSocketUnmask(maskingKey)
+        }
+        return frameData
+    }
+
+    public func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+        let frame = self.unwrapInboundIn(data)
+        switch frame.opcode {
+        case .text, .binary, .continuation:
+            var data = unmaskedData(frame: frame)
+            if frame.opcode == .continuation {
+                buffer.writeBuffer(&data)
+            } else {
+                buffer = data
+            }
+            if frame.fin {
+                client.onMessage(buffer)
+            }
+        case .ping:
+            client.onPing(unmaskedData(frame: frame))
+        case .connectionClose:
+            client.onClose(context.channel)
+        case .pong:
+            client.onPong()
+        default:
+            break
+        }
+    }
+}
+
+class HTTPClientHandler: ChannelInboundHandler, RemovableChannelHandler {
+    typealias InboundIn = HTTPClientResponsePart
+}
+
+extension HTTPVersion {
+    static let http11 = HTTPVersion(major: 1, minor: 1)
+}

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -63,5 +63,6 @@ XCTMain([
     testCase(ComplexTests.allTests.shuffled()),
     testCase(ProtocolErrorTests.allTests.shuffled()),
     testCase(UpgradeErrors.allTests.shuffled()),
-    testCase(InflaterDeflaterTests.allTests.shuffled())
+    testCase(InflaterDeflaterTests.allTests.shuffled()),
+    testCase(ConnectionCleanupTests.allTests.shuffled())
 ].shuffled())


### PR DESCRIPTION
Motivation:

On Kitura-WebSocket https://github.com/IBM-Swift/Kitura-WebSocket/pull/48/
introduces an automatic connection cleanup feature. Using this,
`WebSocketService`s can configure an optional timeout value. If a connection
remains idle for half of the configured timeout value, the server sends a
heartbeat ping to the client. In a following time period, again equal to
half of the configured timeout value, if a pong is received on the connection,
the latter is kept alive. If not, the connection is closed.

In `Kitura-WebSocket-NIO`, we implement this using the `IdleStateHandler` which
is configured with half of the configured timeout value. When we receive the
first `IdleStateEvent`, we send a heartbeat ping to the client. If a pong is
received before the next `IdleStateEvent`, the connection is kept alive. If the
next `IdleStateEvent` is received before the pong, the connection is closed.

This commit also includes a new client framework for testing. It is difficult
to write the connection cleanup tests using the existing adhoc WebSocket client
framework implemented in `KituraTest.swift` and `KituraTest+Frames.swift`. The
new client framework is called `WebSocketClient`. It uses a callback model and
is largely work-in-progress. We must move all of the existing tests to the new
framework in due time.

**Note**: the `IdleStateHandler` is inserted into the pipeline just before the `WebSocketConnection` handler only  if we have a non-nil connection timeout value configured.