### PR TITLE
Update Kitura-NIO version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/IBM-Swift/Kitura-NIO.git", from: "2.0.0"),
+        .package(url: "https://github.com/IBM-Swift/Kitura-NIO.git", from: "2.2.0"),
         .package(url: "https://github.com/IBM-Swift/BlueCryptor.git", from: "1.0.0"),
     ],
     targets: [

--- a/Sources/KituraWebSocket/WebSocketConnection.swift
+++ b/Sources/KituraWebSocket/WebSocketConnection.swift
@@ -193,7 +193,7 @@ extension WebSocketConnection: ChannelInboundHandler {
             }
 
         case .connectionClose:
-            if context != nil {
+            if self.context != nil {
                 let reasonCode: WebSocketErrorCode
                 var description: String?
                 if frame.length >= 2 && frame.length < 126 {

--- a/Tests/KituraWebSocketTests/KituraTest.swift
+++ b/Tests/KituraWebSocketTests/KituraTest.swift
@@ -246,6 +246,5 @@ extension Bool {
     }
 }
 
-// We'd want to able to remove HTTPRequestEncoder and HTTPResponseHandler by hand, following a successful upgrade to WebSocket
-extension HTTPRequestEncoder: RemovableChannelHandler { }
+// We'd want to able to remove HTTPResponseHandler by hand, following a successful upgrade to WebSocket
 extension HTTPResponseHandler: RemovableChannelHandler { }


### PR DESCRIPTION
Though `from: 2.0.0` must suffice here, this change is to make it clear that the upcoming release of `Kitura-WebSocket-NIO` will need `2.2.0`.