### PR TITLE
Remove invalid RSV check block

### DIFF
--- a/Sources/KituraWebSocket/WSConnectionUpgradeFactory.swift
+++ b/Sources/KituraWebSocket/WSConnectionUpgradeFactory.swift
@@ -33,26 +33,14 @@ public class WSConnectionUpgradeFactory: ProtocolHandlerFactory {
 
     /// Return a WebSocketConnection channel handler for the given request
     public func handler(for request: ServerRequest) -> ChannelHandler {
-        let wsRequest = WSServerRequest(request: request)
-        let hasNoExtensions: Bool = hasNoExtensionsConfigured(request: request)
-        
+        let wsRequest = WSServerRequest(request: request)        
         let service = registry[wsRequest.urlURL.path]
 
-        let connection = WebSocketConnection(request: wsRequest, service: service, hasNoExtensions: hasNoExtensions )
+        let connection = WebSocketConnection(request: wsRequest, service: service)
         connection.service = service
 
         return connection
     }
-    
-    ///Return true if extensions are configured in HTTP upgrade header
-    public func hasNoExtensionsConfigured(request: ServerRequest) -> Bool {
-
-        if let  hasNoExtensions = request.headers["sec-websocket-extensions"]?.first?.split(separator: ";").first {
-            return (hasNoExtensions.lowercased() != "permessage-deflate")
-        }
-        return true
-    }
-    
     
     /// Return all the extension handlers enabled for this connection
     public func extensionHandlers(header: String) -> [ChannelHandler] {

--- a/Sources/KituraWebSocket/WSConnectionUpgradeFactory.swift
+++ b/Sources/KituraWebSocket/WSConnectionUpgradeFactory.swift
@@ -48,7 +48,7 @@ public class WSConnectionUpgradeFactory: ProtocolHandlerFactory {
     public func hasNoExtensionsConfigured(request: ServerRequest) -> Bool {
 
         if let  hasNoExtensions = request.headers["sec-websocket-extensions"]?.first?.split(separator: ";").first {
-            return hasNoExtensions.isEmpty
+            return (hasNoExtensions.lowercased() != "permessage-deflate")
         }
         return true
     }

--- a/Sources/KituraWebSocket/WSConnectionUpgradeFactory.swift
+++ b/Sources/KituraWebSocket/WSConnectionUpgradeFactory.swift
@@ -34,14 +34,26 @@ public class WSConnectionUpgradeFactory: ProtocolHandlerFactory {
     /// Return a WebSocketConnection channel handler for the given request
     public func handler(for request: ServerRequest) -> ChannelHandler {
         let wsRequest = WSServerRequest(request: request)
+        let hasNoExtensions: Bool = hasNoExtensionsConfigured(request: request)
+        
         let service = registry[wsRequest.urlURL.path]
 
-        let connection = WebSocketConnection(request: wsRequest, service: service)
+        let connection = WebSocketConnection(request: wsRequest, service: service, hasNoExtensions: hasNoExtensions )
         connection.service = service
 
         return connection
     }
+    
+    ///Return true if extensions are configured in HTTP upgrade header
+    public func hasNoExtensionsConfigured(request: ServerRequest) -> Bool {
 
+        if let  hasNoExtensions = request.headers["sec-websocket-extensions"]?.first?.split(separator: ";").first {
+            return hasNoExtensions.isEmpty
+        }
+        return true
+    }
+    
+    
     /// Return all the extension handlers enabled for this connection
     public func extensionHandlers(header: String) -> [ChannelHandler] {
         var handlers: [ChannelHandler] = []

--- a/Sources/KituraWebSocket/WSConnectionUpgradeFactory.swift
+++ b/Sources/KituraWebSocket/WSConnectionUpgradeFactory.swift
@@ -33,7 +33,7 @@ public class WSConnectionUpgradeFactory: ProtocolHandlerFactory {
 
     /// Return a WebSocketConnection channel handler for the given request
     public func handler(for request: ServerRequest) -> ChannelHandler {
-        let wsRequest = WSServerRequest(request: request)        
+        let wsRequest = WSServerRequest(request: request)
         let service = registry[wsRequest.urlURL.path]
 
         let connection = WebSocketConnection(request: wsRequest, service: service)
@@ -41,7 +41,7 @@ public class WSConnectionUpgradeFactory: ProtocolHandlerFactory {
 
         return connection
     }
-    
+
     /// Return all the extension handlers enabled for this connection
     public func extensionHandlers(header: String) -> [ChannelHandler] {
         var handlers: [ChannelHandler] = []

--- a/Sources/KituraWebSocket/WebSocketConnection.swift
+++ b/Sources/KituraWebSocket/WebSocketConnection.swift
@@ -125,8 +125,7 @@ extension WebSocketConnection: ChannelInboundHandler {
             try validateRSV(frame: frame)
             
         } catch {
-            connectionClosed(reason: .protocolError, description: "\(errors.joined(separator: ",")) must be 0 unless negotiated to defined for non-zero values")
-            return
+            connectionClosed(reason: .protocolError, description: "\(errors.joined(separator: ",")) must be 0 unless negotiated to define meaning for non-zero values")
         }
         
         var data = unmaskedData(frame: frame)

--- a/Sources/KituraWebSocket/WebSocketConnection.swift
+++ b/Sources/KituraWebSocket/WebSocketConnection.swift
@@ -121,13 +121,13 @@ extension WebSocketConnection: ChannelInboundHandler {
         let hasNoExtensions = self.hasNoExtensionsConfigured(request: self.request)
         
         let frame = self.unwrapInboundIn(data)
-        
+
         do {
             try validateRSV(frame: frame, hasNoExtensions: hasNoExtensions)
         } catch {
             connectionClosed(reason: .protocolError, description: "\(errors.joined(separator: ",")) must be 0 unless negotiated to define meaning for non-zero values")
         }
-        
+
         var data = unmaskedData(frame: frame)
         switch frame.opcode {
         case .text:
@@ -288,34 +288,33 @@ extension WebSocketConnection: ChannelInboundHandler {
        }
        return frameData
     }
-    
+
     private enum RSVError: Error {
         case invalidRSV
     }
-    
+
     private func validateRSV(frame: WebSocketFrame, hasNoExtensions: Bool) throws {
-        
+
         if hasNoExtensions && frame.rsv1 {
                 errors.append("RSV1")
         }
-        
+
         if frame.rsv2 {
             errors.append("RSV2")
         }
-        
+
         if frame.rsv3 {
             errors.append("RSV3")
         }
-        
+
         guard errors.isEmpty else {
             throw RSVError.invalidRSV
         }
-        
     }
-    
+
     //HTTP upgrade request header has no extensions configured
     private func hasNoExtensionsConfigured(request: ServerRequest) -> Bool {
-        
+
         if let hasNoExtensions = request.headers["sec-websocket-extensions"]?.first?.split(separator: ";").first {
             return hasNoExtensions != "permessage-deflate"
         }

--- a/Sources/KituraWebSocket/WebSocketConnection.swift
+++ b/Sources/KituraWebSocket/WebSocketConnection.swift
@@ -116,10 +116,10 @@ extension WebSocketConnection: ChannelInboundHandler {
     }
 
     public func channelRead(context: ChannelHandlerContext, data: NIOAny) {
-        
-        //Are no extensions negotiated with WebSocket upgrade request
+
+        // Are no extensions negotiated with WebSocket upgrade request
         let hasNoExtensions = self.hasNoExtensionsConfigured(request: self.request)
-        
+
         let frame = self.unwrapInboundIn(data)
 
         do {
@@ -296,7 +296,7 @@ extension WebSocketConnection: ChannelInboundHandler {
     private func validateRSV(frame: WebSocketFrame, hasNoExtensions: Bool) throws {
 
         if hasNoExtensions && frame.rsv1 {
-                errors.append("RSV1")
+            errors.append("RSV1")
         }
 
         if frame.rsv2 {
@@ -312,9 +312,8 @@ extension WebSocketConnection: ChannelInboundHandler {
         }
     }
 
-    //HTTP upgrade request header has no extensions configured
+    // HTTP upgrade request header has no extensions configured
     private func hasNoExtensionsConfigured(request: ServerRequest) -> Bool {
-
         if let hasNoExtensions = request.headers["sec-websocket-extensions"]?.first?.split(separator: ";").first {
             return hasNoExtensions != "permessage-deflate"
         }
@@ -376,7 +375,7 @@ extension WebSocketConnection {
     }
 }
 
-//Callbacks to the WebSocketService
+//  Callbacks to the WebSocketService
 extension WebSocketConnection {
     func fireConnected() {
         service?.connected(connection: self)

--- a/Tests/KituraWebSocketTests/ProtocolError.swift
+++ b/Tests/KituraWebSocketTests/ProtocolError.swift
@@ -290,8 +290,7 @@ class ProtocolErrorTests: KituraTest {
         
         var bytes = [0x00, 0x01]
         let payload = NSMutableData(bytes: &bytes, length: bytes.count)
-        
-        
+
         performServerTest (asyncTasks: { expectation in
             let expectedPayload = NSMutableData()
             var part = self.payload(closeReasonCode: .protocolError)
@@ -302,7 +301,6 @@ class ProtocolErrorTests: KituraTest {
             self.performTest(framesToSend: [(true, 25, payload)],
                              expectedFrames: [(true, self.opcodeClose, expectedPayload)],
                              expectation: expectation)
-            
         }, { expectation in
             let expectedPayload = NSMutableData()
             var part = self.payload(closeReasonCode: .protocolError)

--- a/Tests/KituraWebSocketTests/ProtocolError.swift
+++ b/Tests/KituraWebSocketTests/ProtocolError.swift
@@ -291,7 +291,7 @@ class ProtocolErrorTests: KituraTest {
         let payload = NSMutableData(bytes: &bytes, length: bytes.count)
         
         
-        performServerTest (asyncTasks:{ expectation in
+        performServerTest (asyncTasks: { expectation in
             let expectedPayload = NSMutableData()
             var part = self.payload(closeReasonCode: .protocolError)
             expectedPayload.append(part.bytes, length: part.length)
@@ -301,8 +301,8 @@ class ProtocolErrorTests: KituraTest {
             self.performTest(framesToSend: [(true, 25, payload)],
                              expectedFrames: [(true, self.opcodeClose, expectedPayload)],
                              expectation: expectation)
-
-        } , { expectation in
+            
+        }, { expectation in
             let expectedPayload = NSMutableData()
             var part = self.payload(closeReasonCode: .protocolError)
             expectedPayload.append(part.bytes, length: part.length)
@@ -312,8 +312,7 @@ class ProtocolErrorTests: KituraTest {
             self.performTest(framesToSend: [(true, 41, payload)],
                              expectedFrames: [(true, self.opcodeClose, expectedPayload)],
                              expectation: expectation)
-//
-        } , { expectation in
+        },{ expectation in
             let expectedPayload = NSMutableData()
             var part = self.payload(closeReasonCode: .protocolError)
             expectedPayload.append(part.bytes, length: part.length)
@@ -324,11 +323,11 @@ class ProtocolErrorTests: KituraTest {
                              expectedFrames: [(true, self.opcodeClose, expectedPayload)],
                              expectation: expectation)
         }, { expectation in
-            // rsv1 is set and compression is negotiated
-            self.performTest(framesToSend: [(true, self.opcodeBinary, payload)],
-                             expectedFrames: [(true, self.opcodeBinary, payload)],
-                             expectation: expectation, negotiateCompression: true,  compressed: true)
-
+            // 73 becomes 1001001 which is a ping and rsv1 is set to 1, set negotiateCompression
+            // ensures compression is negotiated
+            self.performTest(framesToSend: [(true, 73, payload)],
+                             expectedFrames: [(true, self.opcodePong, payload)],
+                             expectation: expectation, negotiateCompression: true, compressed: true)
         })
     }
 }

--- a/Tests/KituraWebSocketTests/ProtocolError.swift
+++ b/Tests/KituraWebSocketTests/ProtocolError.swift
@@ -295,29 +295,29 @@ class ProtocolErrorTests: KituraTest {
             let expectedPayload = NSMutableData()
             var part = self.payload(closeReasonCode: .protocolError)
             expectedPayload.append(part.bytes, length: part.length)
-            part = self.payload(text: "RSV3 must be 0 unless negotiated to defined for non-zero values")
+            part = self.payload(text: "RSV3 must be 0 unless negotiated to define meaning for non-zero values")
             expectedPayload.append(part.bytes, length: part.length)
             // 25 becomes 0011001 which is a ping (op code 9) and rsv3 = 1
             self.performTest(framesToSend: [(true, 25, payload)],
                              expectedFrames: [(true, self.opcodeClose, expectedPayload)],
                              expectation: expectation)
-            
+
         } , { expectation in
             let expectedPayload = NSMutableData()
             var part = self.payload(closeReasonCode: .protocolError)
             expectedPayload.append(part.bytes, length: part.length)
-            part = self.payload(text: "RSV2 must be 0 unless negotiated to defined for non-zero values")
+            part = self.payload(text: "RSV2 must be 0 unless negotiated to define meaning for non-zero values")
             expectedPayload.append(part.bytes, length: part.length)
             // 41 becomes 0101001 which is a ping (op code 9) and rsv2 = 1
             self.performTest(framesToSend: [(true, 41, payload)],
                              expectedFrames: [(true, self.opcodeClose, expectedPayload)],
                              expectation: expectation)
-            
+//
         } , { expectation in
             let expectedPayload = NSMutableData()
             var part = self.payload(closeReasonCode: .protocolError)
             expectedPayload.append(part.bytes, length: part.length)
-            part = self.payload(text: "RSV1 must be 0 unless negotiated to defined for non-zero values")
+            part = self.payload(text: "RSV1 must be 0 unless negotiated to define meaning for non-zero values")
             expectedPayload.append(part.bytes, length: part.length)
             // 74 becomes 1001001 which is a ping (op code 9) and rsv1 = 1
             self.performTest(framesToSend: [(true, 73, payload)],
@@ -325,9 +325,9 @@ class ProtocolErrorTests: KituraTest {
                              expectation: expectation)
         }, { expectation in
             // rsv1 is set and compression is negotiated
-            self.performTest(framesToSend: [(true, self.opcodePing, payload)],
-                             expectedFrames: [(true, self.opcodePong, payload)],
-                             expectation: expectation, negotiateCompression: true, compressed: true)
+            self.performTest(framesToSend: [(true, self.opcodeBinary, payload)],
+                             expectedFrames: [(true, self.opcodeBinary, payload)],
+                             expectation: expectation, negotiateCompression: true,  compressed: true)
 
         })
     }

--- a/Tests/KituraWebSocketTests/ProtocolError.swift
+++ b/Tests/KituraWebSocketTests/ProtocolError.swift
@@ -283,4 +283,52 @@ class ProtocolErrorTests: KituraTest {
                              expectation: expectation)
         }
     }
+    
+    func testInvalidRSVCode() {
+        register(closeReason: .protocolError)
+        
+        var bytes = [0x00, 0x01]
+        let payload = NSMutableData(bytes: &bytes, length: bytes.count)
+        
+        
+        performServerTest (asyncTasks:{ expectation in
+            let expectedPayload = NSMutableData()
+            var part = self.payload(closeReasonCode: .protocolError)
+            expectedPayload.append(part.bytes, length: part.length)
+            part = self.payload(text: "RSV3 must be 0 unless negotiated to defined for non-zero values")
+            expectedPayload.append(part.bytes, length: part.length)
+            // 25 becomes 0011001 which is a ping (op code 9) and rsv3 = 1
+            self.performTest(framesToSend: [(true, 25, payload)],
+                             expectedFrames: [(true, self.opcodeClose, expectedPayload)],
+                             expectation: expectation)
+            
+        } , { expectation in
+            let expectedPayload = NSMutableData()
+            var part = self.payload(closeReasonCode: .protocolError)
+            expectedPayload.append(part.bytes, length: part.length)
+            part = self.payload(text: "RSV2 must be 0 unless negotiated to defined for non-zero values")
+            expectedPayload.append(part.bytes, length: part.length)
+            // 41 becomes 0101001 which is a ping (op code 9) and rsv2 = 1
+            self.performTest(framesToSend: [(true, 41, payload)],
+                             expectedFrames: [(true, self.opcodeClose, expectedPayload)],
+                             expectation: expectation)
+            
+        } , { expectation in
+            let expectedPayload = NSMutableData()
+            var part = self.payload(closeReasonCode: .protocolError)
+            expectedPayload.append(part.bytes, length: part.length)
+            part = self.payload(text: "RSV1 must be 0 unless negotiated to defined for non-zero values")
+            expectedPayload.append(part.bytes, length: part.length)
+            // 74 becomes 1001001 which is a ping (op code 9) and rsv1 = 1
+            self.performTest(framesToSend: [(true, 73, payload)],
+                             expectedFrames: [(true, self.opcodeClose, expectedPayload)],
+                             expectation: expectation)
+        }, { expectation in
+            // rsv1 is set and compression is negotiated
+            self.performTest(framesToSend: [(true, self.opcodePing, payload)],
+                             expectedFrames: [(true, self.opcodePong, payload)],
+                             expectation: expectation, negotiateCompression: true, compressed: true)
+
+        })
+    }
 }

--- a/Tests/KituraWebSocketTests/ProtocolError.swift
+++ b/Tests/KituraWebSocketTests/ProtocolError.swift
@@ -35,7 +35,8 @@ class ProtocolErrorTests: KituraTest {
             ("testInvalidUTF", testInvalidUTF),
             ("testInvalidUTFCloseMessage", testInvalidUTFCloseMessage),
             ("testTextAndBinaryFrames", testTextAndBinaryFrames),
-            ("testUnmaskedFrame", testUnmaskedFrame)
+            ("testUnmaskedFrame", testUnmaskedFrame),
+            ("testInvalidRSVCode", testInvalidRSVCode)
         ]
     }
 

--- a/Tests/KituraWebSocketTests/ProtocolError.swift
+++ b/Tests/KituraWebSocketTests/ProtocolError.swift
@@ -28,7 +28,6 @@ class ProtocolErrorTests: KituraTest {
             ("testPingWithOversizedPayload", testPingWithOversizedPayload),
             ("testFragmentedPing", testFragmentedPing),
             ("testInvalidOpCode", testInvalidOpCode),
-            ("testInvalidRSVCode", testInvalidRSVCode),
             ("testInvalidUserCloseCode", testInvalidUserCloseCode),
             ("testCloseWithOversizedPayload", testCloseWithOversizedPayload),
             ("testJustContinuationFrame", testJustContinuationFrame),
@@ -122,26 +121,6 @@ class ProtocolErrorTests: KituraTest {
             expectedPayload.append(part.bytes, length: part.length)
 
             self.performTest(framesToSend: [(true, 15, payload)],
-                             expectedFrames: [(true, self.opcodeClose, expectedPayload)],
-                             expectation: expectation)
-        }
-    }
-
-    func testInvalidRSVCode() {
-        register(closeReason: .protocolError)
-
-        performServerTest { expectation in
-
-            var bytes = [0x00, 0x01]
-            let payload = NSMutableData(bytes: &bytes, length: bytes.count)
-
-            let expectedPayload = NSMutableData()
-            var part = self.payload(closeReasonCode: .protocolError)
-            expectedPayload.append(part.bytes, length: part.length)
-            part = self.payload(text: "RSV3 must be 0 unless an extension is negotiated that defines meanings for non-zero values")
-            expectedPayload.append(part.bytes, length: part.length)
-            // 25 becomes 0011001 which is a ping (op code 9) and rsv = 1
-            self.performTest(framesToSend: [(true, 25, payload)],
                              expectedFrames: [(true, self.opcodeClose, expectedPayload)],
                              expectation: expectation)
         }


### PR DESCRIPTION
Initially, a set RSV bit in WebSocket frame raised an `inValidRSV` error and
terminated the established WebSocket connection.

This PR changes this behavior and allows for RSV1 bit to be set and negotiate
compression by modifying `validateRSV` check.