### PR TITLE
Use a global ELG for test client

### DIFF
--- a/Tests/KituraWebSocketTests/WebSocketClient.swift
+++ b/Tests/KituraWebSocketTests/WebSocketClient.swift
@@ -26,6 +26,9 @@ import XCTest
     import Glibc
 #endif
 
+// A global EventLoopGroup for the WebSocketClient to use.
+fileprivate let wsClientGlobalELG = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+
 class WebSocketClient {
 
     let requestKey: String
@@ -81,7 +84,7 @@ class WebSocketClient {
         self.maxFrameSize = maxFrameSize
     }
 
-    let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+    let group = wsClientGlobalELG
 
     public var delegate: WebSocketClientDelegate? = nil
 
@@ -345,11 +348,7 @@ class WebSocketClient {
     }
 
     fileprivate func disconnect()  {
-        do {
-            try self.group.syncShutdownGracefully()
-        } catch {
-            return
-        }
+        // Do not close eventLoopGroup as it is shared globally between clients
     }
 }
 


### PR DESCRIPTION
Resolves #52 (you must not shut down an EventLoopGroup on an EventLoop thread)

Once IBM-Swift/Kitura-NIO#225 is merged, we may instead be able to just use Kitura-NIO's global EventLoopGroup rather than creating a new one here.  But since this is just test code, I think it's fine for now.

This problem was introduced in #48 (which hasn't been tagged yet, so we should include this fix in the next tag)

(attn @harish1992, @pushkarnk)